### PR TITLE
removed a link that cran didn't like

### DIFF
--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
 Version: 2.0
-Date: 2022-06-28 08:01:19 UTC
-SHA: abc5cdbe37d01e098edfca67984bd950e74848ab
+Date: 2022-06-28 12:13:55 UTC
+SHA: eca2945bfc30b05e576ab1480aade2a139e49cb4

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ Duration: 1.2 s
 [ FAIL 0 | WARN 0 | SKIP 0 | PASS 111 ]
 
 
-Continuous integration testing is set up using GitHub Actions - see [the workflows](/.github/workflows/).
+Continuous integration testing is set up using GitHub Actions - see the .github directory in the root of this project for more information.
 


### PR DESCRIPTION
CRAN rejected the link to /.github/workflows/ internal directory twice (originally without a trailing slash, then after adding a trailing slash in an attempt to fix it.

Not massively important, so just removed it as a link and instead provided plain text details.